### PR TITLE
Upgrade snforge and delete unnecessary Scarb.toml keys

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-starknet-foundry 0.30.0
+starknet-foundry 0.34.0
 scarb 2.8.1

--- a/crates/cairo-coverage/tests/data/complex_calculator/Scarb.toml
+++ b/crates/cairo-coverage/tests/data/complex_calculator/Scarb.toml
@@ -3,18 +3,11 @@ name = "complex_calculator"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 [dependencies]
 starknet = ">=2.8.0"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.29.0" }
-
-[[target.starknet-contract]]
-sierra = true
-
-[scripts]
-test = "snforge test"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.34.0" }
 
 [profile.dev.cairo]
 unstable-add-statements-functions-debug-info = true

--- a/crates/cairo-coverage/tests/data/coverage_ignore/Scarb.toml
+++ b/crates/cairo-coverage/tests/data/coverage_ignore/Scarb.toml
@@ -3,18 +3,11 @@ name = "coverage_ignore"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 [dependencies]
 starknet = ">=2.8.0"
 
 [dev-dependencies]
-snforge_std = "0.30.0"
-
-[[target.starknet-contract]]
-sierra = true
-
-[scripts]
-test = "snforge test"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.34.0" }
 
 [profile.dev.cairo]
 unstable-add-statements-functions-debug-info = true

--- a/crates/cairo-coverage/tests/data/macros/Scarb.toml
+++ b/crates/cairo-coverage/tests/data/macros/Scarb.toml
@@ -3,18 +3,11 @@ name = "macros"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 [dependencies]
 starknet = ">=2.8.0"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.29.0" }
-
-[[target.starknet-contract]]
-sierra = true
-
-[scripts]
-test = "snforge test"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.34.0" }
 
 [profile.dev.cairo]
 unstable-add-statements-functions-debug-info = true

--- a/crates/cairo-coverage/tests/data/readme_example/Scarb.toml
+++ b/crates/cairo-coverage/tests/data/readme_example/Scarb.toml
@@ -3,18 +3,11 @@ name = "readme_example"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 [dependencies]
 starknet = ">=2.8.0"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.29.0" }
-
-[[target.starknet-contract]]
-sierra = true
-
-[scripts]
-test = "snforge test"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.34.0" }
 
 [profile.dev.cairo]
 unstable-add-statements-functions-debug-info = true

--- a/crates/cairo-coverage/tests/data/scarb_template/Scarb.toml
+++ b/crates/cairo-coverage/tests/data/scarb_template/Scarb.toml
@@ -3,18 +3,11 @@ name = "scarb_template"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 [dependencies]
 starknet = ">=2.8.0"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.29.0" }
-
-[[target.starknet-contract]]
-sierra = true
-
-[scripts]
-test = "snforge test"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.34.0" }
 
 [profile.dev.cairo]
 unstable-add-statements-functions-debug-info = true

--- a/crates/cairo-coverage/tests/data/simple/Scarb.toml
+++ b/crates/cairo-coverage/tests/data/simple/Scarb.toml
@@ -3,18 +3,11 @@ name = "simple"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 [dependencies]
 starknet = ">=2.8.0"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.29.0" }
-
-[[target.starknet-contract]]
-sierra = true
-
-[scripts]
-test = "snforge test"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.34.0" }
 
 [profile.dev.cairo]
 unstable-add-statements-functions-debug-info = true

--- a/crates/cairo-coverage/tests/data/snforge_template/Scarb.toml
+++ b/crates/cairo-coverage/tests/data/snforge_template/Scarb.toml
@@ -3,20 +3,14 @@ name = "snforge_template"
 version = "0.1.0"
 edition = "2023_11"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
-starknet = "2.8.0"
+starknet = ">=2.8.0"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.30.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.34.0" }
 
 [[target.starknet-contract]]
 sierra = true
-
-[scripts]
-test = "snforge test"
-
 
 [profile.dev.cairo]
 unstable-add-statements-functions-debug-info = true


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related https://github.com/software-mansion/cairo-coverage/pull/110#discussion_r1871695182

## Introduced changes

<!-- A brief description of the changes -->

- bump snforge in Scarb.toml and .tools-versions

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
