### PR TITLE
Make run_args optional in CairoCoverageArgs

### DIFF
--- a/crates/cairo-coverage/src/args/mod.rs
+++ b/crates/cairo-coverage/src/args/mod.rs
@@ -11,7 +11,7 @@ pub struct CairoCoverageArgs {
     /// Arguments for the `run` subcommand so user can use
     /// `cairo-coverage` without specifying the subcommand.
     #[clap(flatten)]
-    pub run_args: RunArgs,
+    pub run_args: Option<RunArgs>,
     /// Subcommand and its arguments.
     #[command(subcommand)]
     pub command: Option<Command>,

--- a/crates/cairo-coverage/src/main.rs
+++ b/crates/cairo-coverage/src/main.rs
@@ -13,7 +13,9 @@ fn main() -> Result<()> {
         // TODO:
         // * In 0.5.0 add deprecation warning
         // * In 0.6.0 remove the default command
-        None => Command::Run(cairo_coverage_args.run_args),
+        None => Command::Run(cairo_coverage_args.run_args.unwrap_or_else(|| {
+            unreachable!("`run_args` should be set when no subcommand is provided")
+        })),
     };
 
     commands::run(command)

--- a/crates/cairo-coverage/tests/helpers/test_project.rs
+++ b/crates/cairo-coverage/tests/helpers/test_project.rs
@@ -83,6 +83,7 @@ impl TestProject {
     fn run_coverage(self) -> Self {
         let trace_files = self.find_trace_files();
         SnapboxCommand::new(cargo_bin!("cairo-coverage"))
+            .arg("run")
             .args(&trace_files)
             .args(&self.coverage_args)
             .current_dir(&self.dir)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->


## Introduced changes

<!-- A brief description of the changes -->

- as in title

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
